### PR TITLE
Add support for AWS config profile, and modified a few connection attributes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,10 @@ pub struct Args {
     #[arg(short, long, env = "AWS_REGION")]
     pub region: Option<String>,
 
+    /// AWS profile
+    #[arg(short, long, env = "AWS_PROFILE")]
+    pub profile: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -34,6 +38,9 @@ impl Args {
         let mut loader = aws_config::defaults(BehaviorVersion::latest());
         if let Some(r) = &self.region {
             loader = loader.region(Region::new(r.clone()));
+        }
+        if let Some(p) = &self.profile {
+            loader = loader.profile_name(p);
         }
         loader.load().await
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -41,6 +41,12 @@ impl Bundle {
             bail!("you must specify a user");
         }
 
+        // Configure connection parameters for AWS DSQL
+        config.ssl_negotiation(tokio_postgres::config::SslNegotiation::Postgres);
+        config.connect_timeout(std::time::Duration::from_secs(30));
+        config.keepalives_idle(std::time::Duration::from_secs(600));
+        config.tcp_user_timeout(std::time::Duration::from_secs(60));
+
         // FIXME: Temporary hack for testing against rds
         let connector = if let Ok(pgpass) = std::env::var("PGPASSWORD") {
             config.password(pgpass);


### PR DESCRIPTION
Changed to allow Profiles to be specified on the command line (as addition to AWS_PROFILE env var).
Changed connection attributes to allow for longer connection period.
Changed the SSL negotiation to be Postgres specific, which allows the DSQL verbose error messages to be returned, unless we then try to use a failing IPv6 connection.